### PR TITLE
GitHub Actions: Parallelized builds

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -40,12 +40,12 @@ jobs:
             fi
             cd $WD
     - name: PyDK Build target (non-wasm)
-      if: matrix.target != "wasm"
+      if: matrix.target != 'wasm'
       run: |
             cd /home/runner/work/pydk/pydk
             time sh pydk-all.sh
     - name: PyDK Emscripten build (wasm)
-      if: matrix.target == "wasm"
+      if: matrix.target == 'wasm'
       run: |
             cd /home/runner/work/pydk/pydk
             bash pydk-all.sh

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -5,6 +5,12 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["hostonly", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "wasm"]
+    env:
+      ARCHITECTURES: ${{ matrix.target }}
     steps:
     - uses: actions/checkout@v1
     - name: PyDK prepare
@@ -27,31 +33,19 @@ jobs:
             sudo apt-get install -y  libgl1-mesa-dev libgles2-mesa-dev libglapi-mesa mesa-common-dev libegl1-mesa-dev >/dev/null
             echo panda3d support
             sudo apt-get install -y libbullet-dev libfreetype6-dev libjpeg-dev libode-dev libopenal-dev libpng-dev libssl-dev libogg-dev libvorbis-dev  >/dev/null
-            echo emscripten support
-            git clone https://github.com/emscripten-core/emsdk.git
-            cd emsdk && ./emsdk update-tags && ./emsdk install --embedded latest && ./emsdk activate --embedded latest
+            if [ "$ARCHITECTURES" = "wasm" ]; then
+              echo emscripten support
+              git clone https://github.com/emscripten-core/emsdk.git
+              cd emsdk && ./emsdk update-tags && ./emsdk install --embedded latest && ./emsdk activate --embedded latest
+            fi
             cd $WD
-    - name: PyDK Android build HOST
+    - name: PyDK Build target (non-wasm)
+      if: matrix.target != "wasm"
       run: |
             cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=hostonly time sh pydk-all.sh
-    - name: PyDK Android build armeabi-v7a
+            time sh pydk-all.sh
+    - name: PyDK Emscripten build (wasm)
+      if: matrix.target == "wasm"
       run: |
             cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=armeabi-v7a time sh pydk-all.sh
-    - name: PyDK Android build arm64-v8a
-      run: |
-            cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=arm64-v8a time sh pydk-all.sh
-    - name: PyDK Android build x86
-      run: |
-            cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=x86  time sh pydk-all.sh
-    - name: PyDK Android build x86_64
-      run: |
-            cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=x86_64 time sh pydk-all.sh
-    - name: PyDK Emscripten build wasm
-      run: |
-            cd /home/runner/work/pydk/pydk
-            ARCHITECTURES=wasm bash pydk-all.sh
+            bash pydk-all.sh

--- a/pydk-all.sh
+++ b/pydk-all.sh
@@ -173,7 +173,7 @@ cd "${ROOT}"
 
 # because libpython is shared
 export LD_LIBRARY_PATH=${HOST}/lib64:${HOST}/lib:$LD_LIBRARY_PATH
-export PATH=${HOST}/bin:${ROOT}/bin:$PATH
+export "PATH=${HOST}/bin:${ROOT}/bin:$PATH"
 
 
 for unit in $UNITS
@@ -556,7 +556,7 @@ mkdir -p ${ROOT}
 export TOOLCHAIN="${ORIGIN}/emsdk/emsdk_env.sh"
 
 . $TOOLCHAIN
-export PATH=$PATH:$EMSDK/upstream/emscripten
+export PATH="$PATH:$EMSDK/upstream/emscripten"
 
 export WCMAKE="emcmake $CMAKE -Wno-dev -DCMAKE_INSTALL_PREFIX=${APKUSR}"
 
@@ -568,7 +568,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HOST}/lib64:${HOST}/lib
 
 . ${TOOLCHAIN}
 
-export PATH=\$PATH:$EMSDK/upstream/emscripten
+export PATH="$PATH:$EMSDK/upstream/emscripten"
 
 #export STRIP=$STRIP
 #export READELF=$READELF


### PR DESCRIPTION
This introduces a build matrix to the GitHub Actions configuration that enables each architecture/target to build at the same time. This takes the total time to clear the checks from [2 hours](https://github.com/pmp-p/pydk/actions/runs/131219716) to [1 hour](https://github.com/judge2020/pydk/actions/runs/146654949). 

Since the job strategy has `fail-fast: false`, it will still build other architectures if there is only a problem with one.